### PR TITLE
Removing port no longer required to be mapped.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export TARGET_PORTS=$(sm2 --status | grep PASS | awk -F '|' '{ print $5 }' | tr -d "[:blank:]" | paste -sd "," -),11000,6010
+export TARGET_PORTS=$(sm2 --status | grep PASS | awk -F '|' '{ print $5 }' | tr -d "[:blank:]" | paste -sd "," -),11000
 
 ARCHITECTURE=$(uname -m)
 


### PR DESCRIPTION
6010 was a port used by the accessibility-assessment service. This isn't required in the new tooling/approach.