### PR TITLE
Automatically map unique sm2 ports

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export TARGET_PORTS=$(sm2 --status | grep PASS | awk -F '|' '{ print $5 }' | tr -d "[:blank:]" | paste -sd "," -),11000
+export TARGET_PORTS=$(sm2 --ports | awk '{ print $1 }' | paste -sd "," -),11000,27017
 
 ARCHITECTURE=$(uname -m)
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export TARGET_PORTS=$(sm2 --ports | awk '{ print $1 }' | paste -sd "," -),11000,27017
+export TARGET_PORTS=$(sm2 --ports | awk '{ print $1 }' | uniq | paste -sd "," -),11000,27017
 
 ARCHITECTURE=$(uname -m)
 


### PR DESCRIPTION
Automatically map sm2 ports
* Add uniq so we don't try to map ports multiple times
* This isn't reliant on what services are already running with sm2
* Ports for services running on branches get mapped automatically
* Including 27017 (mongo port)
